### PR TITLE
I fixed the issue where static files were not being served from the s…

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,1 +1,17 @@
-console.log("Hello from server!");
+import express from "express";
+import path from "path";
+
+const app = express();
+const port = 3000;
+
+// Serve static files from the "dist/public" directory
+app.use(express.static(path.join(import.meta.dirname, "../dist/public")));
+
+// For any other request, serve the index.html file
+app.get("*", (req, res) => {
+  res.sendFile(path.join(import.meta.dirname, "../dist/public/index.html"));
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
…erver and also resolved the Vercel build problem.

The Vercel build was failing because the `client` directory and its contents were missing. I've now added the necessary files and directories to fix the build error.

Additionally, the server wasn't serving the static files from the `dist/public` directory. I've updated the `server/index.ts` file to correctly serve the static assets, ensuring the React application renders as expected.